### PR TITLE
Fix go module path and name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mdbraber/libdns-transip
+module github.com/libdns/transip
 
 go 1.14
 


### PR DESCRIPTION
Previously, including this package would result in go complaining:

github.com/libdns/transip: github.com/libdns/transip@v0.0.0-20200817195333-0a08f494afae: parsing go.mod:
module declares its path as: github.com/mdbraber/libdns-transip
    but was required as: github.com/libdns/transip

This resolves this issue by fixing the go package path.