### PR TITLE
Allow FQDNs in zone

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -2,6 +2,7 @@ package transip
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,9 +18,14 @@ type Provider struct {
 	mutex          sync.Mutex
 }
 
+// unFQDN trims any trailing "." from fqdn. TransIP's API does not use FQDNs.
+func (p *Provider) unFQDN(fqdn string) string {
+	return strings.TrimSuffix(fqdn, ".")
+}
+
 // GetRecords lists all the records in the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	records, err := p.getDNSEntries(ctx, zone)
+	records, err := p.getDNSEntries(ctx, p.unFQDN(zone))
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +38,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	var appendedRecords []libdns.Record
 
 	for _, record := range records {
-		newRecord, err := p.addDNSEntry(ctx, zone, record)
+		newRecord, err := p.addDNSEntry(ctx, p.unFQDN(zone), record)
 		if err != nil {
 			return nil, err
 		}
@@ -48,7 +54,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	var deletedRecords []libdns.Record
 
 	for _, record := range records {
-		deletedRecord, err := p.removeDNSEntry(ctx, zone, record)
+		deletedRecord, err := p.removeDNSEntry(ctx, p.unFQDN(zone), record)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +71,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	var setRecords []libdns.Record
 
 	for _, record := range records {
-		setRecord, err := p.updateDNSEntry(ctx, zone, record)
+		setRecord, err := p.updateDNSEntry(ctx, p.unFQDN(zone), record)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hi, I'm experimenting a bit for a caddy-dns implementation for TransIP. 
Caddy supplies the zone as FQDN, which TransIP does not accept resulting in an error: "This is not a valid domain name".
The same was the case for libdns for DigitalOcean, where they resolved the problem https://github.com/libdns/digitalocean/issues/1. 
I basically applied the same changes as https://github.com/libdns/digitalocean/pull/2, which fixes the error for TransIP as well.