### PR TITLE
Fix transip 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zjean/libdns-transip
+module github.com/libdns/transip
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libdns/transip
+module github.com/zjean/lib-transip
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zjean/lib-transip
+module github.com/zjean/libdns-transip
 
 go 1.14
 

--- a/provider.go
+++ b/provider.go
@@ -48,8 +48,6 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 			return nil, err
 		}
 		
-		//newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
-		
 		appendedRecords = append(appendedRecords, newRecord)
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -25,7 +25,7 @@ type Provider struct {
 
 // GetRecords lists all the records in the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	records, err := p.getDNSEntries(ctx, unFQDN(zone))
+	records, err := p.getDNSEntries(ctx, p.unFQDN(zone))
 	if err != nil {
 		return nil, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -38,11 +38,18 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	var appendedRecords []libdns.Record
 
 	for _, record := range records {
+
+		if record.TTL < time.Duration(300)*time.Second {
+			record.TTL = time.Duration(300) * time.Second
+		}
+
 		newRecord, err := p.addDNSEntry(ctx, p.unFQDN(zone), record)
 		if err != nil {
 			return nil, err
 		}
-		newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
+		
+		//newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
+		
 		appendedRecords = append(appendedRecords, newRecord)
 	}
 


### PR DESCRIPTION
- implemented #6 to clean up fqdn
- Set Correct TTL if it is too low, to prevent errors from the transip api.
