### PR TITLE
migrate to libdns v1.1.0 API

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,11 +42,11 @@ func (p *Provider) getDNSEntries(ctx context.Context, domain string) ([]libdns.R
 	}
 
 	for _, entry := range dnsEntries {
-		record := libdns.Record{
-			Name:  entry.Name,
-			Value: entry.Content,
-			Type:  entry.Type,
-			TTL:   time.Duration(entry.Expire) * time.Second,
+		record := libdns.RR{
+			Name: entry.Name,
+			Type: entry.Type,
+			Data: entry.Content,
+			TTL:  time.Duration(entry.Expire) * time.Second,
 		}
 		records = append(records, record)
 	}
@@ -60,19 +60,19 @@ func (p *Provider) addDNSEntry(ctx context.Context, domain string, record libdns
 
 	err := p.setupRepository()
 	if err != nil {
-		return libdns.Record{}, err
+		return record , err
 	}
 
 	entry := transipdomain.DNSEntry{
-		Name:    record.Name,
-		Content: record.Value,
-		Type:    record.Type,
-		Expire:  int(record.TTL.Seconds()),
+		Name:    record.RR().Name,
+		Content: record.RR().Data,
+		Type:    record.RR().Type,
+		Expire:  int(record.RR().TTL.Seconds()),
 	}
 
 	err = p.repository.AddDNSEntry(domain, entry)
 	if err != nil {
-		return libdns.Record{}, err
+		return record, err
 	}
 
 	return record, nil
@@ -84,19 +84,19 @@ func (p *Provider) removeDNSEntry(ctx context.Context, domain string, record lib
 
 	err := p.setupRepository()
 	if err != nil {
-		return libdns.Record{}, err
+		return record, err
 	}
 
 	entry := transipdomain.DNSEntry{
-		Name:    record.Name,
-		Content: record.Value,
-		Type:    record.Type,
-		Expire:  int(record.TTL.Seconds()),
+		Name:    record.RR().Name,
+		Content: record.RR().Data,
+		Type:    record.RR().Type,
+		Expire:  int(record.RR().TTL.Seconds()),
 	}
 
 	err = p.repository.RemoveDNSEntry(domain, entry)
 	if err != nil {
-		return libdns.Record{}, err
+		return record, err
 	}
 
 	return record, nil
@@ -108,19 +108,19 @@ func (p *Provider) updateDNSEntry(ctx context.Context, domain string, record lib
 
 	err := p.setupRepository()
 	if err != nil {
-		return libdns.Record{}, err
+		return record, err
 	}
 
 	entry := transipdomain.DNSEntry{
-		Name:    record.Name,
-		Content: record.Value,
-		Type:    record.Type,
-		Expire:  int(record.TTL.Seconds()),
+		Name:    record.RR().Name,
+		Content: record.RR().Data,
+		Type:    record.RR().Type,
+		Expire:  int(record.RR().TTL.Seconds()),
 	}
 
 	err = p.repository.UpdateDNSEntry(domain, entry)
 	if err != nil {
-		return libdns.Record{}, err
+		return record, err
 	}
 
 	return record, nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/transip
 go 1.14
 
 require (
-	github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821
+	github.com/libdns/libdns v1.1.0
 	github.com/transip/gotransip/v6 v6.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,13 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821 h1:663opx/RKxiISi1ozf0WbvweQpYBgf34dx8hKSIau3w=
-github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/transip/gotransip/v6 v6.1.0 h1:t8wV8jKPKf58dQWqWQAUXa5HznpUWKutkqugCV+5IDA=
-github.com/transip/gotransip/v6 v6.1.0/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 github.com/transip/gotransip/v6 v6.6.1 h1:nsCU1ErZS5G0FeOpgGXc4FsWvBff9GPswSMggsC4564=
 github.com/transip/gotransip/v6 v6.6.1/go.mod h1:pQZ36hWWRahCUXkFWlx9Hs711gLd8J4qdgLdRzmtY+g=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/provider.go
+++ b/provider.go
@@ -39,8 +39,10 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 
 	for _, record := range records {
 
-		if record.TTL < time.Duration(300)*time.Second {
-			record.TTL = time.Duration(300) * time.Second
+		if record.RR().TTL < time.Duration(300)*time.Second {
+			var rr = record.RR()
+			rr.TTL = time.Duration(300) * time.Second
+			record = rr
 		}
 
 		newRecord, err := p.addDNSEntry(ctx, p.unFQDN(zone), record)
@@ -63,7 +65,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		deletedRecord.TTL = time.Duration(deletedRecord.TTL) * time.Second
+		// deletedRecord.TTL = time.Duration(deletedRecord.RR().TTL) * time.Second
 		deletedRecords = append(deletedRecords, deletedRecord)
 	}
 
@@ -80,7 +82,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		if err != nil {
 			return nil, err
 		}
-		setRecord.TTL = time.Duration(setRecord.TTL) * time.Second
+		// setRecord.TTL = time.Duration(setRecord.TTL) * time.Second
 		setRecords = append(setRecords, setRecord)
 	}
 


### PR DESCRIPTION
This is an attempt at porting this code to be compatible with the latest release of `libdns`. Note that I am not a golang programmer, so I may have made some silly mistakes, but this does compile and I am able to get working certificates using caddy 2.10.0 and the transip API with this.

(NB. No AI was involved!)
